### PR TITLE
Fix README with correct instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "decidim-extra_user_fields"
+gem "decidim-extra_user_fields", git: "https://github.com/PopulateTools/decidim-module-extra_user_fields"
 ```
 
 And then execute:


### PR DESCRIPTION
As the module is not published to rubygems.org, the instructions wouldn't work.

You get this error:

```bash
$ bundle
Fetching gem metadata from https://rubygems.org/.........
Could not find gem 'decidim-extra_user_fields' in any of the gem sources listed in your Gemfile.
```

This PR fixes that.