### PR TITLE
[Feature] - Allow admin to enable / disable extra user fields

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,41 @@
 # frozen_string_literal: true
 
+# Copy of https://github.com/mainio/decidim-module-term_customizer/blob/master/Rakefile
 require "decidim/dev/common_rake"
 
-desc "Generates a dummy app for testing"
-task test_app: "decidim:generate_external_test_app"
+def install_module(path)
+  Dir.chdir(path) do
+    system("bundle exec rake decidim_extra_user_fields:install:migrations")
+    system("bundle exec rake db:migrate")
+  end
+end
 
-desc "Generates a development app."
-task development_app: "decidim:generate_external_development_app"
+def seed_db(path)
+  Dir.chdir(path) do
+    system("bundle exec rake db:seed")
+  end
+end
+
+desc "Generates a dummy app for testing"
+task test_app: "decidim:generate_external_test_app" do
+  ENV["RAILS_ENV"] = "test"
+  install_module("spec/decidim_dummy_app")
+end
+
+desc "Generates a development app"
+task :development_app do
+  Bundler.with_original_env do
+    generate_decidim_app(
+      "development_app",
+      "--app_name",
+      "#{base_app_name}_development_app",
+      "--path",
+      "..",
+      "--recreate_db",
+      "--demo"
+    )
+  end
+
+  install_module("development_app")
+  seed_db("development_app")
+end

--- a/app/commands/decidim/extra_user_fields/admin/update_extra_user_fields.rb
+++ b/app/commands/decidim/extra_user_fields/admin/update_extra_user_fields.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ExtraUserFields
+    module Admin
+      # A command with all the business logic when updating organization's extra user fields in signup form
+      class UpdateExtraUserFields < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # form - A form object with the params.
+        def initialize(form)
+          @form = form
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          update_extra_user_fields!
+
+          broadcast(:ok)
+        end
+
+        private
+
+        attr_reader :form
+
+        def update_extra_user_fields!
+          Decidim.traceability.update!(
+            form.current_organization,
+            form.current_user,
+            extra_user_fields: extra_user_fields
+          )
+        end
+
+        def extra_user_fields
+          {
+            "enabled" => form.extra_user_fields_enabled.presence || false
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/commands/decidim/extra_user_fields/admin/update_extra_user_fields.rb
+++ b/app/commands/decidim/extra_user_fields/admin/update_extra_user_fields.rb
@@ -40,7 +40,7 @@ module Decidim
 
         def extra_user_fields
           {
-            "enabled" => form.extra_user_fields_enabled.presence || false
+            "enabled" => form.enabled.presence || false
           }
         end
       end

--- a/app/commands/decidim/extra_user_fields/admin/update_extra_user_fields.rb
+++ b/app/commands/decidim/extra_user_fields/admin/update_extra_user_fields.rb
@@ -40,7 +40,11 @@ module Decidim
 
         def extra_user_fields
           {
-            "enabled" => form.enabled.presence || false
+            "enabled" => form.enabled.presence || false,
+            "date_of_birth" => { "enabled" => form.date_of_birth.presence || false },
+            "country" => { "enabled" => form.country.presence || false },
+            "postal_code" => { "enabled" => form.postal_code.presence || false },
+            "gender" => { "enabled" => form.gender.presence || false }
           }
         end
       end

--- a/app/controllers/decidim/extra_user_fields/admin/application_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/application_controller.rb
@@ -6,6 +6,17 @@ module Decidim
       # This controller is the abstract class from which all other controllers of
       # this engine inherit.
       class ApplicationController < Decidim::Admin::ApplicationController
+        def permission_class_chain
+          [::Decidim::ExtraUserFields::Admin::Permissions] + super
+        end
+
+        def user_not_authorized_path
+          decidim.root_path
+        end
+
+        def user_has_no_permission_path
+          decidim.root_path
+        end
       end
     end
   end

--- a/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
@@ -12,6 +12,25 @@ module Decidim
           @form = form(ExtraUserFieldsForm).instance
         end
 
+        def create
+          @form = form(ExtraUserFieldsForm).from_params(
+            params,
+            current_organization: current_organization
+          )
+
+          UpdateExtraUserFields.call(@form) do
+            on(:ok) do
+              flash[:notice] = t(".success")
+              render action: "index"
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = t(".failure")
+              render action: "index"
+            end
+          end
+        end
+
         def export_users
           enforce_permission_to :read, :officialization
 

--- a/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
@@ -9,10 +9,14 @@ module Decidim
         layout "decidim/admin/settings"
 
         def index
+          enforce_permission_to :read, :extra_user_fields
+
           @form = form(ExtraUserFieldsForm).from_model(current_organization)
         end
 
         def update
+          enforce_permission_to :update, :extra_user_fields
+
           @form = form(ExtraUserFieldsForm).from_params(
             params,
             current_organization: current_organization

--- a/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
@@ -9,10 +9,10 @@ module Decidim
         layout "decidim/admin/settings"
 
         def index
-          @form = form(ExtraUserFieldsForm).instance
+          @form = form(ExtraUserFieldsForm).from_model(current_organization)
         end
 
-        def create
+        def update
           @form = form(ExtraUserFieldsForm).from_params(
             params,
             current_organization: current_organization

--- a/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
@@ -6,6 +6,12 @@ module Decidim
       # This controller is the abstract class from which all other controllers of
       # this engine inherit.
       class ExtraUserFieldsController < Admin::ApplicationController
+        layout "decidim/admin/settings"
+
+        def index
+          @form = form(ExtraUserFieldsForm).instance
+        end
+
         def export_users
           enforce_permission_to :read, :officialization
 

--- a/app/forms/concerns/decidim/extra_user_fields/forms_definitions.rb
+++ b/app/forms/concerns/decidim/extra_user_fields/forms_definitions.rb
@@ -19,7 +19,7 @@ module Decidim
         validates :country, presence: true, if: :country?
         validates :postal_code, presence: true, if: :postal_code?
         validates :date_of_birth, presence: true, if: :date_of_birth?
-        validates :gender, presence: true, if: :gender?
+        validates :gender, presence: true, inclusion: { in: Decidim::ExtraUserFields::Engine::DEFAULT_GENDER_OPTIONS.map(&:to_s) }, if: :gender?
       end
 
       def map_model(model)

--- a/app/forms/concerns/decidim/extra_user_fields/forms_definitions.rb
+++ b/app/forms/concerns/decidim/extra_user_fields/forms_definitions.rb
@@ -34,19 +34,19 @@ module Decidim
       private
 
       def country?
-        extra_user_fields_enabled
+        extra_user_fields_enabled && current_organization.activated_extra_field?(:country)
       end
 
       def date_of_birth?
-        extra_user_fields_enabled
+        extra_user_fields_enabled && current_organization.activated_extra_field?(:date_of_birth)
       end
 
       def gender?
-        extra_user_fields_enabled
+        extra_user_fields_enabled && current_organization.activated_extra_field?(:gender)
       end
 
       def postal_code?
-        extra_user_fields_enabled
+        extra_user_fields_enabled && current_organization.activated_extra_field?(:postal_code)
       end
 
       def extra_user_fields_enabled

--- a/app/forms/concerns/decidim/extra_user_fields/forms_definitions.rb
+++ b/app/forms/concerns/decidim/extra_user_fields/forms_definitions.rb
@@ -16,10 +16,10 @@ module Decidim
         attribute :date_of_birth, Decidim::Attributes::LocalizedDate
         attribute :gender, String
 
-        validates :country, presence: true
-        validates :postal_code, presence: true
-        validates :date_of_birth, presence: true
-        validates :gender, presence: true
+        validates :country, presence: true, if: :country?
+        validates :postal_code, presence: true, if: :postal_code?
+        validates :date_of_birth, presence: true, if: :date_of_birth?
+        validates :gender, presence: true, if: :gender?
       end
 
       def map_model(model)
@@ -29,6 +29,28 @@ module Decidim
         self.postal_code = extended_data[:postal_code]
         self.date_of_birth = Date.parse(extended_data[:date_of_birth]) if extended_data[:date_of_birth].present?
         self.gender = extended_data[:gender]
+      end
+
+      private
+
+      def country?
+        extra_user_fields_enabled
+      end
+
+      def date_of_birth?
+        extra_user_fields_enabled
+      end
+
+      def gender?
+        extra_user_fields_enabled
+      end
+
+      def postal_code?
+        extra_user_fields_enabled
+      end
+
+      def extra_user_fields_enabled
+        @extra_user_fields_enabled ||= current_organization.extra_user_fields_enabled?
       end
     end
   end

--- a/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
+++ b/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
@@ -7,9 +7,17 @@ module Decidim
         include TranslatableAttributes
 
         attribute :enabled, Virtus::Attribute::Boolean
+        attribute :country, Virtus::Attribute::Boolean
+        attribute :postal_code, Virtus::Attribute::Boolean
+        attribute :date_of_birth, Virtus::Attribute::Boolean
+        attribute :gender, Virtus::Attribute::Boolean
 
         def map_model(model)
           self.enabled = model.extra_user_fields["enabled"]
+          self.country = model.extra_user_fields.dig(:country, :enabled)
+          self.postal_code = model.extra_user_fields.dig(:postal_code, :enabled)
+          self.date_of_birth = model.extra_user_fields.dig(:date_of_birth, :enabled)
+          self.gender = model.extra_user_fields.dig(:gender, :enabled)
         end
       end
     end

--- a/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
+++ b/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
@@ -6,7 +6,11 @@ module Decidim
       class ExtraUserFieldsForm < Decidim::Form
         include TranslatableAttributes
 
-        attribute :extra_user_fields_enabled, Virtus::Attribute::Boolean
+        attribute :enabled, Virtus::Attribute::Boolean
+
+        def map_model(model)
+          self.enabled = model.extra_user_fields["enabled"]
+        end
       end
     end
   end

--- a/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
+++ b/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ExtraUserFields
+    module Admin
+      class ExtraUserFieldsForm < Decidim::Form
+        include TranslatableAttributes
+
+        attribute :extra_user_fields_enabled, Virtus::Attribute::Boolean
+      end
+    end
+  end
+end

--- a/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
+++ b/app/forms/decidim/extra_user_fields/admin/extra_user_fields_form.rb
@@ -14,10 +14,10 @@ module Decidim
 
         def map_model(model)
           self.enabled = model.extra_user_fields["enabled"]
-          self.country = model.extra_user_fields.dig(:country, :enabled)
-          self.postal_code = model.extra_user_fields.dig(:postal_code, :enabled)
-          self.date_of_birth = model.extra_user_fields.dig(:date_of_birth, :enabled)
-          self.gender = model.extra_user_fields.dig(:gender, :enabled)
+          self.country = model.extra_user_fields.dig("country", "enabled")
+          self.postal_code = model.extra_user_fields.dig("postal_code", "enabled")
+          self.date_of_birth = model.extra_user_fields.dig("date_of_birth", "enabled")
+          self.gender = model.extra_user_fields.dig("gender", "enabled")
         end
       end
     end

--- a/app/models/concerns/decidim/extra_user_fields/organization_overrides.rb
+++ b/app/models/concerns/decidim/extra_user_fields/organization_overrides.rb
@@ -10,14 +10,16 @@ module Decidim
 
       # If true display registration field in signup form
       def extra_user_fields_enabled?
-        activated_extra_field?(:enabled)
+        extra_user_fields["enabled"].presence && at_least_one_extra_field?
+      end
+
+      def at_least_one_extra_field?
+        extra_user_fields.reject { |key| key == "enabled" }.map { |_, value| value["enabled"] }.include?(true)
       end
 
       # Check if the given value is enabled in extra_user_fields
       def activated_extra_field?(sym)
-        return false if extra_user_fields[sym.to_s].blank?
-
-        extra_user_fields[sym.to_s]
+        extra_user_fields.dig(sym.to_s, "enabled")
       end
     end
   end

--- a/app/models/concerns/decidim/extra_user_fields/organization_overrides.rb
+++ b/app/models/concerns/decidim/extra_user_fields/organization_overrides.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module ExtraUserFields
+    # Changes in methods to store extra fields in user profile
+    module OrganizationOverrides
+      extend ActiveSupport::Concern
+
+      # If true display registration field in signup form
+      def extra_user_fields_enabled?
+        activated_extra_field?(:enabled)
+      end
+
+      # Check if the given value is enabled in extra_user_fields
+      def activated_extra_field?(sym)
+        return false if extra_user_fields[sym.to_s].blank?
+
+        extra_user_fields[sym.to_s]
+      end
+    end
+  end
+end

--- a/app/overrides/decidim/devise/registrations/new/extra_user_fields.html.erb.deface
+++ b/app/overrides/decidim/devise/registrations/new/extra_user_fields.html.erb.deface
@@ -1,3 +1,3 @@
-<!-- insert_after "erb[loud]:contains('email_field')" -->
+<!-- insert_before "#card__tos" -->
 
 <%= render partial: "/decidim/extra_user_fields/registration_form", locals: { f: f } %>

--- a/app/permissions/decidim/extra_user_fields/admin/permissions.rb
+++ b/app/permissions/decidim/extra_user_fields/admin/permissions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ExtraUserFields
+    module Admin
+      class Permissions < Decidim::DefaultPermissions
+        def permissions
+          return permission_action if permission_action.scope != :admin
+          return permission_action unless user&.admin?
+
+          allow! if access_extra_user_fields?
+          allow! if update_extra_user_fields?
+
+          permission_action
+        end
+
+        def access_extra_user_fields?
+          permission_action.subject == :extra_user_fields &&
+            permission_action.action == :read
+        end
+
+        def update_extra_user_fields?
+          permission_action.subject == :extra_user_fields &&
+            permission_action.action == :update
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/extra_user_fields/_profile_form.html.erb
+++ b/app/views/decidim/extra_user_fields/_profile_form.html.erb
@@ -1,4 +1,14 @@
-<%= f.date_field :date_of_birth %>
-<%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
-<%= f.custom_country_select :country %>
-<%= f.text_field :postal_code %>
+<% if current_organization.activated_extra_field?(:date_of_birth) %>
+  <%= f.date_field :date_of_birth %>
+<% end %>
+<% if current_organization.activated_extra_field?(:gender) %>
+  <%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
+<% end %>
+
+<% if current_organization.activated_extra_field?(:country) %>
+  <%= f.custom_country_select :country %>
+<% end %>
+
+<% if current_organization.activated_extra_field?(:postal_code) %>
+  <%= f.text_field :postal_code %>
+<% end %>

--- a/app/views/decidim/extra_user_fields/_registration_form.html.erb
+++ b/app/views/decidim/extra_user_fields/_registration_form.html.erb
@@ -1,17 +1,28 @@
+
 <% if current_organization.extra_user_fields_enabled? %>
-  <div class="field">
+
+
+  <% if current_organization.activated_extra_field?(:date_of_birth) %>
+    <div class="field">
       <%= f.date_field :date_of_birth %>
-  </div>
+    </div>
+  <% end %>
 
-  <div class="field">
-    <%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
-  </div>
+  <% if current_organization.activated_extra_field?(:gender) %>
+    <div class="field">
+      <%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
+    </div>
+  <% end %>
 
-  <div class="field">
-    <%= f.custom_country_select :country %>
-  </div>
+  <% if current_organization.activated_extra_field?(:country) %>
+    <div class="field">
+      <%= f.custom_country_select :country %>
+    </div>
+  <% end %>
 
-  <div class="field">
-    <%= f.text_field :postal_code %>
-  </div>
+  <% if current_organization.activated_extra_field?(:postal_code) %>
+    <div class="field">
+      <%= f.text_field :postal_code %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/decidim/extra_user_fields/_registration_form.html.erb
+++ b/app/views/decidim/extra_user_fields/_registration_form.html.erb
@@ -1,15 +1,17 @@
-<div class="field">
-    <%= f.date_field :date_of_birth %>
-</div>
+<% if current_organization.extra_user_fields_enabled? %>
+  <div class="field">
+      <%= f.date_field :date_of_birth %>
+  </div>
 
-<div class="field">
-  <%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
-</div>
+  <div class="field">
+    <%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
+  </div>
 
-<div class="field">
-  <%= f.custom_country_select :country %>
-</div>
+  <div class="field">
+    <%= f.custom_country_select :country %>
+  </div>
 
-<div class="field">
-  <%= f.text_field :postal_code %>
-</div>
+  <div class="field">
+    <%= f.text_field :postal_code %>
+  </div>
+<% end %>

--- a/app/views/decidim/extra_user_fields/_registration_form.html.erb
+++ b/app/views/decidim/extra_user_fields/_registration_form.html.erb
@@ -1,28 +1,33 @@
-
 <% if current_organization.extra_user_fields_enabled? %>
+  <div class="card">
+    <div class="card__content card__extra_user_fields">
+      <div class="legend">
+        <h3><%= t(".signup.legend") %></h3>
+      </div>
 
+      <% if current_organization.activated_extra_field?(:date_of_birth) %>
+        <div class="field">
+          <%= f.date_field :date_of_birth %>
+        </div>
+      <% end %>
 
-  <% if current_organization.activated_extra_field?(:date_of_birth) %>
-    <div class="field">
-      <%= f.date_field :date_of_birth %>
+      <% if current_organization.activated_extra_field?(:gender) %>
+        <div class="field">
+          <%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
+        </div>
+      <% end %>
+
+      <% if current_organization.activated_extra_field?(:country) %>
+        <div class="field">
+          <%= f.custom_country_select :country %>
+        </div>
+      <% end %>
+
+      <% if current_organization.activated_extra_field?(:postal_code) %>
+        <div class="field">
+          <%= f.text_field :postal_code %>
+        </div>
+      <% end %>
     </div>
-  <% end %>
-
-  <% if current_organization.activated_extra_field?(:gender) %>
-    <div class="field">
-      <%= f.collection_select :gender, f.object.gender_options_for_select, :first, :last %>
-    </div>
-  <% end %>
-
-  <% if current_organization.activated_extra_field?(:country) %>
-    <div class="field">
-      <%= f.custom_country_select :country %>
-    </div>
-  <% end %>
-
-  <% if current_organization.activated_extra_field?(:postal_code) %>
-    <div class="field">
-      <%= f.text_field :postal_code %>
-    </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/_form.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/_form.html.erb
@@ -1,0 +1,19 @@
+<p class="callout success"><%== t(".callout.help") %></p>
+<div class="card">
+  <div class="card-section extra_user_fields">
+    <div>
+      <h3><%= t(".global.title") %></h3>
+    </div>
+    <div class="row column">
+      <%= form.check_box :extra_user_fields_enabled, label: "Enable extra user fields" %>
+    </div>
+  </div>
+</div>
+
+<div class="card extra_fields_setup">
+  <div class="card-section">
+    <div>
+      <h3><%= t(".extra_user_fields.section") %></h3>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/_form.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/_form.html.erb
@@ -5,7 +5,7 @@
       <h3><%= t(".global.title") %></h3>
     </div>
     <div class="row column">
-      <%= form.check_box :extra_user_fields_enabled, label: "Enable extra user fields" %>
+      <%= form.check_box :enabled, label: t(".extra_user_fields.extra_user_fields_enabled") %>
     </div>
   </div>
 </div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/_form.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/_form.html.erb
@@ -15,5 +15,10 @@
     <div>
       <h3><%= t(".extra_user_fields.section") %></h3>
     </div>
+
+    <%= render partial: "decidim/extra_user_fields/admin/extra_user_fields/fields/date_of_birth", locals: { form: form } %>
+    <%= render partial: "decidim/extra_user_fields/admin/extra_user_fields/fields/country", locals: { form: form } %>
+    <%= render partial: "decidim/extra_user_fields/admin/extra_user_fields/fields/postal_code", locals: { form: form } %>
+    <%= render partial: "decidim/extra_user_fields/admin/extra_user_fields/fields/gender", locals: { form: form } %>
   </div>
 </div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_country.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_country.html.erb
@@ -1,0 +1,6 @@
+<div class="card-section">
+  <div class="row column">
+    <p><%= t(".description") %></p>
+    <%= form.check_box :country, label: t(".label") %>
+  </div>
+</div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_date_of_birth.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_date_of_birth.html.erb
@@ -1,0 +1,6 @@
+<div class="card-section">
+  <div class="row column">
+    <p><%= t(".description") %></p>
+    <%= form.check_box :date_of_birth, label: t(".label") %>
+  </div>
+</div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_gender.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_gender.html.erb
@@ -1,0 +1,6 @@
+<div class="card-section">
+  <div class="row column">
+    <p><%= t(".description") %></p>
+    <%= form.check_box :gender, label: t(".label") %>
+  </div>
+</div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_postal_code.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/fields/_postal_code.html.erb
@@ -1,0 +1,6 @@
+<div class="card-section">
+  <div class="row column">
+    <p><%= t(".description") %></p>
+    <%= form.check_box :postal_code, label: t(".label") %>
+  </div>
+</div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/index.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/index.html.erb
@@ -1,0 +1,16 @@
+<div class="card" id="extra_user_fields">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t ".title" %>
+    </h2>
+  </div>
+  <div class="card-section">
+    <%= decidim_form_for(@form, html: { class: "form edit_extra_user_fields" }) do |f| %>
+      <%= render partial: "form", object: f %>
+
+      <div class="button--double form-general-submit">
+        <%= f.submit t(".save") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/index.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/index.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <div class="card-section">
-    <%= decidim_form_for(@form, html: { class: "form edit_extra_user_fields" }) do |f| %>
+    <%= decidim_form_for(@form, url: "/admin/extra_user_fields/extra_user_fields", html: { class: "form edit_extra_user_fields" }) do |f| %>
       <%= render partial: "form", object: f %>
 
       <div class="button--double form-general-submit">

--- a/app/views/decidim/extra_user_fields/admin/extra_user_fields/index.html.erb
+++ b/app/views/decidim/extra_user_fields/admin/extra_user_fields/index.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <div class="card-section">
-    <%= decidim_form_for(@form, url: "/admin/extra_user_fields/extra_user_fields", html: { class: "form edit_extra_user_fields" }) do |f| %>
+    <%= decidim_form_for(@form, url: "/admin/extra_user_fields/extra_user_fields", html: { class: "form edit_extra_user_fields" }, method: :patch) do |f| %>
       <%= render partial: "form", object: f %>
 
       <div class="button--double form-general-submit">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,9 @@ en:
     extra_user_fields:
       admin:
         extra_user_fields:
+          create:
+            failure: An error occurred on update
+            success: Extra user fields correctly updated in organization
           form:
             extra_user_fields:
               section: Available extra fields for signup form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,20 @@ en:
     extra_user_fields:
       admin:
         extra_user_fields:
+          fields:
+            country:
+              description: This field is a list of countries. User will be able to choose a country
+              label: Enable country field
+            date_of_birth:
+              description: This field is a Date field. User will be able to register
+                a birth date by using a Date picker
+              label: Enable date of birth field
+            gender:
+              description: This field is a list of genders. User will be able to choose a gender
+              label: Enable gender field
+            postal_code:
+              description: This field is a String field. User will be able to fill in a postal code
+              label: Enable postal code field
           update:
             failure: An error occurred on update
             success: Extra user fields correctly updated in organization

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,11 +8,28 @@ en:
         gender: Gender
         postal_code: Postal code
   decidim:
+    admin:
+      extra_user_fields:
+        menu:
+          title: Manage extra user fields
     components:
       extra_user_fields:
         name: ExtraUserFields
     extra_user_fields:
       admin:
+        extra_user_fields:
+          form:
+            extra_user_fields:
+              section: Available extra fields for signup form
+            global:
+              title: Activate / deactivate functionality
+            callout:
+              help: Enable custom extra user fields functionality to be able to manage extra fields
+                in your signup form. Even if option is checked, signup form will be
+                updated <strong>only if there is at least one extra field enabled</strong>
+          index:
+            save: Save configuration
+            title: Manage extra user fields
         exports:
           users: Participants
       genders:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,12 +18,13 @@ en:
     extra_user_fields:
       admin:
         extra_user_fields:
-          create:
+          update:
             failure: An error occurred on update
             success: Extra user fields correctly updated in organization
           form:
             extra_user_fields:
               section: Available extra fields for signup form
+              extra_user_fields_enabled: Enable extra user fields
             global:
               title: Activate / deactivate functionality
             callout:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,9 @@ en:
       extra_user_fields:
         name: ExtraUserFields
     extra_user_fields:
+      registration_form:
+        signup:
+          legend: More information
       admin:
         extra_user_fields:
           fields:

--- a/db/migrate/20221024121407_add_extra_user_fields_to_decidim_organization.rb
+++ b/db/migrate/20221024121407_add_extra_user_fields_to_decidim_organization.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddExtraUserFieldsToDecidimOrganization < ActiveRecord::Migration[6.0]
+  def up
+    add_column :decidim_organizations, :extra_user_fields, :jsonb, default: { "enabled" => false }
+  end
+
+  def down
+    remove_column :decidim_organizations, :extra_user_fields, :jsonb
+  end
+end

--- a/lib/decidim/extra_user_fields/admin_engine.rb
+++ b/lib/decidim/extra_user_fields/admin_engine.rb
@@ -13,8 +13,10 @@ module Decidim
 
       routes do
         namespace :extra_user_fields do
-          get :index
           get :export_users
+        end
+
+        resources :extra_user_fields, only: [:index, :create] do
         end
 
         root to: "extra_user_fields#index"

--- a/lib/decidim/extra_user_fields/admin_engine.rb
+++ b/lib/decidim/extra_user_fields/admin_engine.rb
@@ -16,8 +16,8 @@ module Decidim
           get :export_users
         end
 
-        resources :extra_user_fields, only: [:index, :create] do
-        end
+        resources :extra_user_fields, only: [:index]
+        match "/extra_user_fields" => "extra_user_fields#update", :via => :patch, as: "update"
 
         root to: "extra_user_fields#index"
       end

--- a/lib/decidim/extra_user_fields/admin_engine.rb
+++ b/lib/decidim/extra_user_fields/admin_engine.rb
@@ -12,10 +12,12 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        # Add admin engine routes here
         namespace :extra_user_fields do
+          get :index
           get :export_users
         end
+
+        root to: "extra_user_fields#index"
       end
 
       initializer "decidim_extra_user_fields.admin_mount_routes" do
@@ -29,6 +31,15 @@ module Decidim
           Decidim::Admin::ApplicationHelper.class_eval do
             include ExtraUserFields::Admin::ApplicationHelper
           end
+        end
+      end
+
+      initializer "decidim_extra_user_fields.admin_settings_menu" do
+        Decidim.menu :admin_settings_menu do |menu|
+          menu.add_item :extra_user_fields,
+                        t("decidim.admin.extra_user_fields.menu.title"),
+                        decidim_extra_user_fields.root_path,
+                        position: 11
         end
       end
 

--- a/lib/decidim/extra_user_fields/engine.rb
+++ b/lib/decidim/extra_user_fields/engine.rb
@@ -45,6 +45,14 @@ module Decidim
             prepend ExtraUserFields::CommandsOverrides
           end
 
+          Decidim::Organization.class_eval do
+            prepend ExtraUserFields::OrganizationOverrides
+          end
+
+          Decidim::FormBuilder.class_eval do
+            include ExtraUserFields::FormBuilderMethods
+          end
+
           Decidim::FormBuilder.class_eval do
             include ExtraUserFields::FormBuilderMethods
           end

--- a/spec/commands/decidim/extra_user_fields/admin/update_extra_user_fields_spec.rb
+++ b/spec/commands/decidim/extra_user_fields/admin/update_extra_user_fields_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ExtraUserFields
+    module Admin
+      describe UpdateExtraUserFields do
+        let(:organization) { create(:organization, extra_user_fields: {}) }
+        let(:user) { create :user, :admin, :confirmed, organization: organization }
+
+        let(:extra_user_fields_enabled) { true }
+        let(:form_params) do
+          {
+            "extra_user_fields_enabled" => extra_user_fields_enabled
+          }
+        end
+        let(:form) do
+          ExtraUserFieldsForm.from_params(
+            form_params
+          ).with_context(
+            current_user: user,
+            current_organization: organization
+          )
+        end
+        let(:command) { described_class.new(form) }
+
+        describe "call" do
+          context "when the form is not valid" do
+            before do
+              expect(form).to receive(:invalid?).and_return(true)
+            end
+
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+
+            it "doesn't update the registration fields" do
+              expect do
+                command.call
+                organization.reload
+              end.not_to change(organization, :extra_user_fields)
+            end
+          end
+
+          context "when the form is valid" do
+            it "broadcasts ok" do
+              expect { command.call }.to broadcast(:ok)
+            end
+
+            it "updates the organization registration fields" do
+              command.call
+              organization.reload
+
+              expect(organization.extra_user_fields).to eq({ "enabled" => true })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/extra_user_fields/admin/update_extra_user_fields_spec.rb
+++ b/spec/commands/decidim/extra_user_fields/admin/update_extra_user_fields_spec.rb
@@ -10,9 +10,17 @@ module Decidim
         let(:user) { create :user, :admin, :confirmed, organization: organization }
 
         let(:extra_user_fields_enabled) { true }
+        let(:postal_code) { true }
+        let(:country) { true }
+        let(:gender) { true }
+        let(:date_of_birth) { true }
         let(:form_params) do
           {
-            "enabled" => extra_user_fields_enabled
+            "enabled" => extra_user_fields_enabled,
+            "postal_code" => postal_code,
+            "country" => country,
+            "gender" => gender,
+            "date_of_birth" => date_of_birth
           }
         end
         let(:form) do
@@ -52,7 +60,13 @@ module Decidim
               command.call
               organization.reload
 
-              expect(organization.extra_user_fields).to eq({ "enabled" => true })
+              expect(organization.extra_user_fields).to eq({
+                                                             "enabled" => true,
+                                                             "country" => { "enabled" => true },
+                                                             "date_of_birth" => { "enabled" => true },
+                                                             "gender" => { "enabled" => true },
+                                                             "postal_code" => { "enabled" => true }
+                                                           })
             end
           end
         end

--- a/spec/commands/decidim/extra_user_fields/admin/update_extra_user_fields_spec.rb
+++ b/spec/commands/decidim/extra_user_fields/admin/update_extra_user_fields_spec.rb
@@ -12,7 +12,7 @@ module Decidim
         let(:extra_user_fields_enabled) { true }
         let(:form_params) do
           {
-            "extra_user_fields_enabled" => extra_user_fields_enabled
+            "enabled" => extra_user_fields_enabled
           }
         end
         let(:form) do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,74 @@
 # frozen_string_literal: true
 
 require "decidim/extra_user_fields/test/factories"
+
+FactoryBot.modify do
+  factory :organization, class: "Decidim::Organization" do
+    transient do
+      create_static_pages { true }
+    end
+
+    name { Faker::Company.unique.name }
+    reference_prefix { Faker::Name.suffix }
+    time_zone { "UTC" }
+    twitter_handler { Faker::Hipster.word }
+    facebook_handler { Faker::Hipster.word }
+    instagram_handler { Faker::Hipster.word }
+    youtube_handler { Faker::Hipster.word }
+    github_handler { Faker::Hipster.word }
+    sequence(:host) { |n| "#{n}.lvh.me" }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    favicon { Decidim::Dev.test_file("icon.png", "image/png") }
+    default_locale { Decidim.default_locale }
+    available_locales { Decidim.available_locales }
+    users_registration_mode { :enabled }
+    official_img_header { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
+    official_img_footer { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
+    official_url { Faker::Internet.url }
+    highlighted_content_banner_enabled { false }
+    enable_omnipresent_banner { false }
+    badges_enabled { true }
+    user_groups_enabled { true }
+    send_welcome_notification { true }
+    comments_max_length { 1000 }
+    admin_terms_of_use_body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    force_users_to_authenticate_before_access_organization { false }
+    machine_translation_display_priority { "original" }
+    external_domain_whitelist { ["example.org", "twitter.com", "facebook.com", "youtube.com", "github.com", "mytesturl.me"] }
+    smtp_settings do
+      {
+        "from" => "test@example.org",
+        "user_name" => "test",
+        "encrypted_password" => Decidim::AttributeEncryptor.encrypt("demo"),
+        "port" => "25",
+        "address" => "smtp.example.org"
+      }
+    end
+    file_upload_settings { Decidim::OrganizationSettings.default(:upload) }
+    enable_participatory_space_filters { true }
+    extra_user_fields do
+      {
+        "enabled" => true
+      }
+    end
+
+    trait :extra_user_fields_disabled do
+      extra_user_fields do
+        {
+          "enabled" => false
+        }
+      end
+    end
+
+    trait :secure_context do
+      host { "localhost" }
+    end
+
+    after(:create) do |organization, evaluator|
+      if evaluator.create_static_pages
+        tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization)
+        create(:static_page, :tos, organization: organization) if tos_page.nil?
+      end
+    end
+  end
+end

--- a/spec/forms/decidim/admin/extra_user_fields_form_spec.rb
+++ b/spec/forms/decidim/admin/extra_user_fields_form_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ExtraUserFields
+    module Admin
+      describe ExtraUserFieldsForm do
+        subject do
+          described_class.from_params(
+            attributes
+          ).with_context(
+            context
+          )
+        end
+
+        let(:organization) { create(:organization) }
+        let(:extra_user_fields) { true }
+
+        let(:attributes) do
+          {
+            extra_user_fields: extra_user_fields
+          }
+        end
+
+        let(:context) do
+          {
+            current_organization: organization
+          }
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/decidim/organization_spec.rb
+++ b/spec/models/decidim/organization_spec.rb
@@ -8,9 +8,13 @@ module Decidim
 
     let(:extra_user_fields) do
       {
-        "enabled" => true,
-        "date_of_birth" => true
+        "enabled" => extra_user_field,
+        "date_of_birth" => date_of_birth
       }
+    end
+    let(:extra_user_field) { true }
+    let(:date_of_birth) do
+      { "enabled" => true }
     end
 
     it { is_expected.to be_valid }
@@ -22,11 +26,7 @@ module Decidim
       end
 
       context "when extra user fields are disabled" do
-        let(:extra_user_fields) do
-          {
-            "enabled" => false
-          }
-        end
+        let(:extra_user_field) { false }
 
         it "returns true" do
           expect(subject).not_to be_extra_user_fields_enabled
@@ -40,20 +40,15 @@ module Decidim
       end
 
       context "when given key doesn't exist in hash" do
-        it "returns falsey" do
+        it "returns false" do
           expect(subject).not_to be_activated_extra_field(:unknown)
         end
       end
 
       context "when value for given key is nil" do
-        let(:extra_user_fields) do
-          {
-            "enabled" => true,
-            "date_of_birth" => nil
-          }
-        end
+        let(:date_of_birth) { nil }
 
-        it "returns falsey" do
+        it "returns false" do
           expect(subject).not_to be_activated_extra_field(:date_of_birth)
         end
       end

--- a/spec/models/decidim/organization_spec.rb
+++ b/spec/models/decidim/organization_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Organization do
+    subject(:organization) { build(:organization, extra_user_fields: extra_user_fields) }
+
+    let(:extra_user_fields) do
+      {
+        "enabled" => true,
+        "date_of_birth" => true
+      }
+    end
+
+    it { is_expected.to be_valid }
+    it { is_expected.to be_versioned }
+
+    describe "#extra_user_fields_enabled?" do
+      it "returns true" do
+        expect(subject).to be_extra_user_fields_enabled
+      end
+
+      context "when extra user fields are disabled" do
+        let(:extra_user_fields) do
+          {
+            "enabled" => false
+          }
+        end
+
+        it "returns true" do
+          expect(subject).not_to be_extra_user_fields_enabled
+        end
+      end
+    end
+
+    describe "#activated_extra_field?" do
+      it "returns the value of given key" do
+        expect(subject).to be_activated_extra_field(:date_of_birth)
+      end
+
+      context "when given key doesn't exist in hash" do
+        it "returns falsey" do
+          expect(subject).not_to be_activated_extra_field(:unknown)
+        end
+      end
+
+      context "when value for given key is nil" do
+        let(:extra_user_fields) do
+          {
+            "enabled" => true,
+            "date_of_birth" => nil
+          }
+        end
+
+        it "returns falsey" do
+          expect(subject).not_to be_activated_extra_field(:date_of_birth)
+        end
+      end
+    end
+  end
+end

--- a/spec/permissions/admin/permissions_spec.rb
+++ b/spec/permissions/admin/permissions_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ExtraUserFields::Admin
+  describe Permissions do
+    subject { described_class.new(user, permission_action, context).permissions.allowed? }
+
+    let(:organization) { create :organization }
+    let(:context) do
+      {
+        current_organization: organization
+      }
+    end
+    let(:action) do
+      { scope: :admin, action: :read, subject: :extra_user_fields }
+    end
+    let(:permission_action) { Decidim::PermissionAction.new(action) }
+
+    context "when user is admin" do
+      let(:user) { create :user, :admin, organization: organization }
+
+      it { is_expected.to be_truthy }
+
+      context "when scope is not admin" do
+        let(:action) do
+          { scope: :foo, action: :read, subject: :extra_user_fields }
+        end
+
+        it_behaves_like "permission is not set"
+      end
+    end
+
+    context "when user is not admin" do
+      let(:user) { create :user, organization: organization }
+
+      context "and tries to read extra user fields" do
+        let(:action) do
+          { scope: :admin, action: :read, subject: :extra_user_fields }
+        end
+
+        it_behaves_like "permission is not set"
+      end
+
+      context "and tries to update extra user fields" do
+        let(:action) do
+          { scope: :admin, action: :update, subject: :extra_user_fields }
+        end
+
+        it_behaves_like "permission is not set"
+      end
+    end
+  end
+end

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -3,9 +3,40 @@
 require "spec_helper"
 
 describe "Account", type: :system do
-  let(:user) { create(:user, :confirmed, password: password, password_confirmation: password) }
+  shared_examples_for "does not display extra user field" do |field, label|
+    it "does not display field '#{field}'" do
+      expect(page).not_to have_content(label)
+    end
+  end
+
+  let(:organization) { create(:organization, extra_user_fields: extra_user_fields) }
+  let(:user) { create(:user, :confirmed, organization: organization, password: password, password_confirmation: password) }
   let(:password) { "dqCFgjfDbC7dPbrv" }
-  let(:organization) { user.organization }
+  let(:extra_user_fields) do
+    {
+      "enabled" => true,
+      "date_of_birth" => date_of_birth,
+      "postal_code" => postal_code,
+      "gender" => gender,
+      "country" => country
+    }
+  end
+
+  let(:date_of_birth) do
+    { "enabled" => true }
+  end
+
+  let(:postal_code) do
+    { "enabled" => true }
+  end
+
+  let(:country) do
+    { "enabled" => true }
+  end
+
+  let(:gender) do
+    { "enabled" => true }
+  end
 
   before do
     switch_to_host(organization.host)
@@ -41,6 +72,38 @@ describe "Account", type: :system do
           expect(page).to have_content("Nikola Tesla")
         end
       end
+    end
+
+    context "when date_of_birth is not enabled" do
+      let(:date_of_birth) do
+        { "enabled" => false }
+      end
+
+      it_behaves_like "does not display extra user field", "date_of_birth", "Date of birth"
+    end
+
+    context "when postal_code is not enabled" do
+      let(:postal_code) do
+        { "enabled" => false }
+      end
+
+      it_behaves_like "does not display extra user field", "postal_code", "Postal code"
+    end
+
+    context "when country is not enabled" do
+      let(:country) do
+        { "enabled" => false }
+      end
+
+      it_behaves_like "does not display extra user field", "country", "Country"
+    end
+
+    context "when gender is not enabled" do
+      let(:gender) do
+        { "enabled" => false }
+      end
+
+      it_behaves_like "does not display extra user field", "gender", "Gender"
     end
   end
 end

--- a/spec/system/admin_manages_organization_extra_user_fields_spec.rb
+++ b/spec/system/admin_manages_organization_extra_user_fields_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages organization extra user fields", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  it "creates a new item in submenu" do
+    visit decidim_admin.edit_organization_path
+
+    within ".secondary-nav" do
+      expect(page).to have_content("Manage extra user fields")
+    end
+  end
+
+  context "when accessing extra user fields" do
+    before do
+      visit decidim_extra_user_fields.root_path
+    end
+
+    it "displays the form" do
+      within "#extra_user_fields" do
+        expect(page).to have_content("Manage extra user fields")
+      end
+    end
+
+    it "allows to enable extra user fields functionality" do
+      within ".extra_user_fields" do
+        expect(page).to have_content("Enable extra user fields")
+      end
+
+      within ".extra_fields_setup" do
+        expect(page).to have_content("Available extra fields for signup form")
+      end
+    end
+  end
+end

--- a/spec/system/admin_manages_organization_extra_user_fields_spec.rb
+++ b/spec/system/admin_manages_organization_extra_user_fields_spec.rb
@@ -42,7 +42,7 @@ describe "Admin manages organization extra user fields", type: :system do
 
     context "when form is valid" do
       it "flashes a success message" do
-        page.check("extra_user_fields[extra_user_fields_enabled]")
+        page.check("extra_user_fields[enabled]")
 
         find("*[type=submit]").click
         expect(page).to have_content("Extra user fields correctly updated in organization")

--- a/spec/system/admin_manages_organization_extra_user_fields_spec.rb
+++ b/spec/system/admin_manages_organization_extra_user_fields_spec.rb
@@ -39,5 +39,14 @@ describe "Admin manages organization extra user fields", type: :system do
         expect(page).to have_content("Available extra fields for signup form")
       end
     end
+
+    context "when form is valid" do
+      it "flashes a success message" do
+        page.check("extra_user_fields[extra_user_fields_enabled]")
+
+        find("*[type=submit]").click
+        expect(page).to have_content("Extra user fields correctly updated in organization")
+      end
+    end
   end
 end

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -28,8 +28,33 @@ describe "Extra user fields", type: :system do
     end
   end
 
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, extra_user_fields: extra_user_fields) }
   let!(:terms_and_conditions_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization) }
+  let(:extra_user_fields) do
+    {
+      "enabled" => true,
+      "date_of_birth" => date_of_birth,
+      "postal_code" => postal_code,
+      "gender" => gender,
+      "country" => country
+    }
+  end
+
+  let(:date_of_birth) do
+    { "enabled" => true }
+  end
+
+  let(:postal_code) do
+    { "enabled" => true }
+  end
+
+  let(:country) do
+    { "enabled" => true }
+  end
+
+  let(:gender) do
+    { "enabled" => true }
+  end
 
   before do
     switch_to_host(organization.host)

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -43,8 +43,30 @@ describe "Extra user fields", type: :system do
     expect(page).to have_content("Postal code")
   end
 
+  it "allows to create a new account" do
+    fill_registration_form
+    fill_extra_user_fields
+
+    within "form.new_user" do
+      find("*[type=submit]").click
+    end
+
+    expect(page).to have_content("message with a confirmation link has been sent")
+  end
+
   it_behaves_like "mandatory extra user fields", "date_of_birth"
   it_behaves_like "mandatory extra user fields", "gender"
   it_behaves_like "mandatory extra user fields", "country"
   it_behaves_like "mandatory extra user fields", "postal_code"
+
+  context "when extra_user_fields is disabled" do
+    let(:organization) { create(:organization, :extra_user_fields_disabled) }
+
+    it "does not contain extra user fields" do
+      expect(page).not_to have_content("Date of birth")
+      expect(page).not_to have_content("Gender")
+      expect(page).not_to have_content("Country")
+      expect(page).not_to have_content("Postal code")
+    end
+  end
 end

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -62,10 +62,12 @@ describe "Extra user fields", type: :system do
   end
 
   it "contains extra user fields" do
-    expect(page).to have_content("Date of birth")
-    expect(page).to have_content("Gender")
-    expect(page).to have_content("Country")
-    expect(page).to have_content("Postal code")
+    within ".card__extra_user_fields" do
+      expect(page).to have_content("Date of birth")
+      expect(page).to have_content("Gender")
+      expect(page).to have_content("Country")
+      expect(page).to have_content("Postal code")
+    end
   end
 
   it "allows to create a new account" do

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -68,5 +68,15 @@ describe "Extra user fields", type: :system do
       expect(page).not_to have_content("Country")
       expect(page).not_to have_content("Postal code")
     end
+
+    it "allows to create a new account" do
+      fill_registration_form
+
+      within "form.new_user" do
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("message with a confirmation link has been sent")
+    end
   end
 end


### PR DESCRIPTION
#### Description

This PR implements the possibility for admins to enable / disable extra user fields in the signup form. Also, admins can choose which field available to add to the registration form.

When the extra user field is enabled, and at least one field is selected, a new section will be add to the registration form and account form.

#### Related to

Issue #8, see issue for screenshots

#### How to test

1. Add the migration to the application (it creates a new column `extra_user_fields` to the organizations table)
2. Log in as admin, and go to Settings > Manage extra user fields
3. Enable the extra user field and at least one field
4. Go to registration form, see the fields
5. Go to account form, see the new fields

#### Information

* Exports does not take in account if fields are enabled or not
* extra_user_fields column is a jsonb with this format
```
{
  "enabled" => Boolean,
  "custom_field" => { "enabled" => Boolean }
}
```

The choice of Hash for field in the jsonb column seems to me easier for future needs.

#### Tasks

- [x] Create new migration
- [x] Add configuration form in BO
- [x] Toggle fields in registration form / account form
- [x] Add specs
- [x] Add inclusion validation for gender field
- [x] Add admin permissions for new controller
- [ ] Add documentation for creating a new field => I am thinking about adding documentation in another PR, because there is a lot of steps I think having a task for create skeleton of new field can be interesting ?

#### Additionnal information

Feel free to suggest or ask for changes.

Thanks